### PR TITLE
trigger refresh on all events

### DIFF
--- a/others/refresh-on-content-change.ts
+++ b/others/refresh-on-content-change.ts
@@ -5,34 +5,37 @@ import { postJSON } from './utils'
 
 const watchPath = path.resolve(process.cwd(), 'content')
 const refreshPath = path.resolve(process.cwd(), 'app', 'refresh.ignore.js')
+const watcher = chokidar.watch(watchPath)
 
-chokidar.watch(watchPath).on('change', changePath => {
-  const relativeChangePath = changePath.replace(
-    `${path.resolve(process.cwd(), 'content')}/`,
-    '',
-  )
-  console.log('🛠 content changed', relativeChangePath)
+watcher.on('ready', () => {
+  watcher.on('all', (_eventName, changePath) => {
+    const relativeChangePath = changePath.replace(
+      `${path.resolve(process.cwd(), 'content')}/`,
+      '',
+    )
+    console.log('🛠 content changed', relativeChangePath)
 
-  postJSON({
-    http: require('http'),
-    postData: {
-      paths: [relativeChangePath],
-    },
-    overrideOptions: {
-      hostname: 'localhost',
-      port: 3000,
-      path: `/_content/update-content?${new URLSearchParams([
-        ['_data', 'routes/_content/update-content'],
-      ])}`,
-    },
+    postJSON({
+      http: require('http'),
+      postData: {
+        paths: [relativeChangePath],
+      },
+      overrideOptions: {
+        hostname: 'localhost',
+        port: 3000,
+        path: `/_content/update-content?${new URLSearchParams([
+          ['_data', 'routes/_content/update-content'],
+        ])}`,
+      },
+    })
+      .then(() => {
+        console.log('🚀 Finished updating content')
+        setTimeout(() => {
+          fs.writeFileSync(refreshPath, `// ${new Date()}`)
+        }, 250)
+      })
+      .catch(err => {
+        console.error(err)
+      })
   })
-    .then(() => {
-      console.log('🚀 Finished updating content')
-      setTimeout(() => {
-        fs.writeFileSync(refreshPath, `// ${new Date()}`)
-      }, 250)
-    })
-    .catch(err => {
-      console.error(err)
-    })
 })


### PR DESCRIPTION
Previously, chokidar was configured to only respond to `change` events. This means it would not detect delete events (i.e if you delete the `.mdx` or blog post directory).

This PR fixes this issue so that refresh-on-content-change will trigger from all event types. 

Closes #13.